### PR TITLE
fix: Configure base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig({
+  base: "/ProyectoFinanzasPyme/",
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
This commit updates the Vite configuration to set the `base` property. This is necessary for the application to be deployed correctly to a subdirectory, such as on GitHub Pages.